### PR TITLE
Update Managed Restate deployment to use new CDK construct

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,16 @@ Instead, we have 4 Lambda deployments, each corresponding to a single service fr
 - The [Car service](./src/cars.ts), with methods for reserve/confirm/cancel
 - The [Payment service](./src/payments.ts), with methods for process/refund
 
-## Deploying with self-hosted Restate instance
+## Prerequisites
+
+This example assumes you have the following installed:
+
+- [A current version of Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
+- [An AWS account](https://aws.amazon.com/) and sufficient permissions to deploy the required resources
+- [AWS CLI](https://aws.amazon.com/cli/)
+- [curl](https://curl.se)
+
+## Deploying the Holiday Service and a self-hosted Restate instance
 
 In order to accept incoming requests over HTTPS we need a certificate to use with the Restate ingress endpoint. If you
 have a certificate you would like to use, you can specify it in the `INGRESS_CERTIFICATE_ARN` environment variable.
@@ -42,7 +51,8 @@ Alternatively, you can create and import a new self-signed certificate:
 ```shell
 bin/create-certificate.sh
 export INGRESS_CERTIFICATE_ARN=$(aws acm list-certificates \
-  --query "CertificateSummaryList[?DomainName=='restate.example.com'].CertificateArn" --output text)
+  --query "CertificateSummaryList[?DomainName=='restate.example.com'].CertificateArn" \
+  --output text)
 ```
 
 You can also set the certificate ARN via the `ingressCertificateArn` CDK context attribute, either on the command line
@@ -55,11 +65,8 @@ By default, the Holiday CDK app will deploy two stacks: a self-hosted Restate in
 npx cdk deploy --all
 ```
 
-If you are deploying this stack in a shared AWS account, you may want to specify a prefix for the stack names:
-
-```shell
-npx cdk deploy --all --context prefix=${USER}
-```
+If you are deploying this stack in a shared AWS account, you may want to specify a prefix for the stack names and other
+resource names that require uniqueness by appending `--context prefix=${USER}` to the CDK `deploy` command.
 
 You can also deploy only the self-hosted Restate stack as follows:
 
@@ -87,21 +94,56 @@ during deployment, you will need to use the same value here too):
 npx cdk destroy --all
 ```
 
-## Deploying against Restate managed service
+## Deploying on Restate managed service
 
-`MANAGED_SERVICE_CLUSTER=<your-cluster> cdk deploy` will set up everything you need in your AWS account. To discover the Lambdas to your managed Restate cluster:
+You should have two pieces of information about your managed cluster: its identifier and an authentication token for the
+Restate API endpoints.
+
+Create a secret in Secrets Manager to hold the authentication token. The secret name is up to you -- we suggest
+using `/restate/` and an appropriate prefix to avoid confusion:
 
 ```shell
-# get stack outputs into your shell
-eval $(aws cloudformation describe-stacks --stack RestateHolidayStack  --query "Stacks[].Outputs[]" | jq -r '.[] | "export " + .ExportName + "=" + .OutputValue')
-for arn in ${tripsLambdaArn} ${carsLambdaArn} ${paymentsLambdaArn} ${flightsLambdaArn}; do
-  curl -H "Authorization: Bearer <your-cluster-token>" https://<your-cluster>.dev.restate.cloud:9070/endpoints --json "{\"arn\": \"$arn\", \"assume_role_arn\": \"${assumeRoleArn}\"}"
-done
+export AUTH_TOKEN_ARN=$(aws secretsmanager create-secret \
+    --name /restate/${CLUSTER_ID}/auth-token --secret-string ${RESTATE_AUTH_TOKEN} \
+    --query ARN --output text
+)
 ```
 
-This discovered a specific version, so you'll need to run this again if you update the Lambda functions.
+Once you have the ARN for the secret, deploying the Holiday demo app is as easy as:
 
-See [the Managed Service docs](https://docs.restate.dev/restate/managed_service#giving-permission-for-your-cluster-to-invoke-your-lambdas) for more information
+```shell
+npx cdk deploy --all \
+    --context deploymentMode=managed \
+    --context clusterId=${CLUSTER_ID} \
+    --context authTokenSecretArn=${AUTH_TOKEN_ARN}
+```
+
+Just like with the self-hosted stack you can also specify a unique prefix if you wish to deploy multiple copies of these
+stacks to the same AWS account with `--context prefix=${USER}`. You can also save these context attributes in the
+`cdk.json` file to avoid repetition for subsequent CDK operations.
+
+For managed clusters, the Restate ingress URL will be known upfront. You can also grab it from the deployment outputs:
+
+```shell
+export INGRESS=$(aws cloudformation describe-stacks \
+    --stack-name RestateStack \
+    --query "Stacks[0].Outputs[?OutputKey=='RestateIngressEndpoint'].OutputValue" \
+    --output text)
+```
+You are now ready to jump to [Invoking](#Invoking) and send some requests to the service.
+
+See the [Managed Service documentation](https://docs.restate.dev/restate/managed_service#giving-permission-for-your-cluster-to-invoke-your-lambdas)
+for more information about the managed Restate offering.
+
+When you are done testing, you can easily delete all created resources with the command (if you specified a prefix
+during deployment, you will need to use the same value here too):
+
+```shell
+npx cdk destroy --all \
+    --context deploymentMode=managed \
+    --context clusterId=${CLUSTER_ID} \
+    --context authTokenSecretArn=${AUTH_TOKEN_ARN}
+```
 
 ## Deploying against local Restate
 

--- a/bin/create-auth-token-secret.sh
+++ b/bin/create-auth-token-secret.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env zsh
+
+set -euo pipefail
+
+aws secretsmanager create-secret --name /restate/${PREFIX}/auth-token --secret-string ${RESTATE_AUTH_TOKEN}

--- a/bin/create-self-signed-certificate.sh
+++ b/bin/create-self-signed-certificate.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env zsh
-
-set -euo pipefail
-
-openssl genrsa 2048 > restate-ingress-private.key
-openssl req -new -x509 -nodes -sha256 -days 365 -extensions v3_ca -key restate-ingress-private.key \
-  -subj "/C=DE/ST=Berlin/L=Berlin/O=restatedev/OU=demo/CN=restate.example.com" > restate-ingress-public.crt
-
-aws acm import-certificate --certificate fileb://restate-ingress-public.crt --private-key fileb://restate-ingress-private.key

--- a/lib/holiday-service-stack.ts
+++ b/lib/holiday-service-stack.ts
@@ -12,7 +12,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import { BillingMode } from "aws-cdk-lib/aws-dynamodb";
-import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as restate from "@restatedev/restate-cdk";
 import * as sns from "aws-cdk-lib/aws-sns";
@@ -22,17 +21,12 @@ import { NodejsFunction } from "aws-cdk-lib/aws-lambda-nodejs";
 
 export interface HolidayServiceStackProps extends cdk.StackProps {
   /**
-   * If set, create a role for the Restate managed service to assume with permission to invoke Lambda handlers.
-   */
-  managedServiceClusterId?: string;
-
-  /**
    * Provides details of the Restate instance with which to register services.
    */
-  restateInstance?: restate.RestateInstance;
+  restateInstance: restate.RestateInstance;
 
   /**
-   * Service registration token obtained from the Restate construct {@link restate.SingleNodeRestateInstance#registrationProviderToken}.
+   * Service registration token obtained from the Restate construct {@link restate.RestateInstance#registrationProviderToken}.
    */
   registrationProviderToken: string;
 
@@ -42,100 +36,74 @@ export interface HolidayServiceStackProps extends cdk.StackProps {
   prefix?: string;
 }
 
+/**
+ * Stack defining a set of service handlers. This stack is agnostic of the type of Restate service – self-hosted
+ * or managed service – that will be used.
+ */
 export class HolidayServiceStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: HolidayServiceStackProps) {
     super(scope, id, props);
 
-    // Create Dynamo DB tables for flights, car rental reservations, and payments information.
-    const flightTable = new dynamodb.Table(this, "Flights", {
+    const flightsTable = new dynamodb.Table(this, "Flights", {
       partitionKey: { name: "pk", type: dynamodb.AttributeType.STRING },
       sortKey: { name: "sk", type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       billingMode: BillingMode.PAY_PER_REQUEST,
     });
-    // new cdk.CfnOutput(this, "FlightTable", { value: flightTable.tableName, exportName: "flightsTableName" });
 
-    const rentalTable = new dynamodb.Table(this, "Rentals", {
+    const rentalsTable = new dynamodb.Table(this, "Rentals", {
       partitionKey: { name: "pk", type: dynamodb.AttributeType.STRING },
       sortKey: { name: "sk", type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       billingMode: BillingMode.PAY_PER_REQUEST,
     });
-    // new cdk.CfnOutput(this, "CarTable", { value: rentalTable.tableName, exportName: "carsTableName" });
 
-    const paymentTable = new dynamodb.Table(this, "Payments", {
+    const paymentsTable = new dynamodb.Table(this, "Payments", {
       partitionKey: { name: "pk", type: dynamodb.AttributeType.STRING },
       sortKey: { name: "sk", type: dynamodb.AttributeType.STRING },
       removalPolicy: cdk.RemovalPolicy.DESTROY,
       billingMode: BillingMode.PAY_PER_REQUEST,
     });
-    // new cdk.CfnOutput(this, "PaymentTable", { value: paymentTable.tableName, exportName: "paymentsTableName" });
 
     // SNS Topic, Subscription configuration
     const topic = new sns.Topic(this, "Topic");
     topic.addSubscription(new subscriptions.SmsSubscription("+11111111111"));
 
     // Lambda deployments of Restate service handlers: Trips provides the main entry point, and orchestrates the rest.
-    const tripLambda = lambdaHandler(this, "TripHandler", "src/trips.ts", { SNS_TOPIC: topic.topicArn });
+    const tripLambda = lambdaHandler(this, "TripHandler", "src/trips.ts", {
+      SNS_TOPIC: topic.topicArn,
+    });
     topic.grantPublish(tripLambda);
-    // new cdk.CfnOutput(this, "TripLambda", { value: tripLambda.currentVersion.functionArn, exportName: "tripsLambdaArn" });
 
     const flightLambda = lambdaHandler(this, "FlightHandler", "src/flights.ts", {
-      FLIGHTS_TABLE_NAME: flightTable.tableName,
+      FLIGHTS_TABLE_NAME: flightsTable.tableName,
     });
-    flightTable.grantReadWriteData(flightLambda);
-    // new cdk.CfnOutput(this, "FlightLambda", {
-    //   value: flightLambda.currentVersion.functionArn,
-    //   exportName: "flightsLambdaArn",
-    // });
+    flightsTable.grantReadWriteData(flightLambda);
 
     const rentalLambda = lambdaHandler(this, "RentalHandler", "src/cars.ts", {
-      CARS_TABLE_NAME: rentalTable.tableName,
+      CARS_TABLE_NAME: rentalsTable.tableName,
     });
-    rentalTable.grantReadWriteData(rentalLambda);
-    // new cdk.CfnOutput(this, "CarLambda", { value: rentalLambda.currentVersion.functionArn, exportName: "carsLambdaArn" });
+    rentalsTable.grantReadWriteData(rentalLambda);
 
     const paymentLambda = lambdaHandler(this, "PaymentHandler", "src/payments.ts", {
-      PAYMENTS_TABLE_NAME: paymentTable.tableName,
+      PAYMENTS_TABLE_NAME: paymentsTable.tableName,
     });
-    paymentTable.grantReadWriteData(paymentLambda);
-    // new cdk.CfnOutput(this, "PaymentLambda", {
-    //   value: paymentLambda.currentVersion.functionArn,
-    //   exportName: "paymentsLambdaArn",
-    // });
+    paymentsTable.grantReadWriteData(paymentLambda);
 
-    if (props?.managedServiceClusterId) {
-      const managed_service_role = new iam.Role(this, "RestateManagedServiceRole", {
-        assumedBy: new iam.ArnPrincipal("arn:aws:iam::663487780041:role/restate-dev"),
-        externalIds: [props.managedServiceClusterId],
-      });
-
-      for (const lambda of [flightLambda, rentalLambda, paymentLambda, tripLambda]) {
-        lambda.grantInvoke(managed_service_role);
-      }
-
-      // new cdk.CfnOutput(this, "ManagedServiceAssumeRole", {
-      //   value: managed_service_role.roleArn,
-      //   exportName: "assumeRoleArn",
-      // });
-    } else {
-      const lambdaServices = new restate.LambdaServiceRegistry(this, "RestateServices", {
-        serviceHandlers: {
-          trips: tripLambda,
-          flights: flightLambda,
-          cars: rentalLambda,
-          payments: paymentLambda,
-        },
-        registrationProviderToken: props.registrationProviderToken,
-      });
-
-      if (props?.restateInstance) {
-        lambdaServices.register({
-          invokerRoleArn: props.restateInstance.invokerRole.roleArn,
-          metaEndpoint: props.restateInstance.metaEndpoint,
-        });
-      }
-    }
+    const handlers = new restate.LambdaServiceRegistry(this, "RestateServices", {
+      serviceHandlers: {
+        trips: tripLambda,
+        flights: flightLambda,
+        cars: rentalLambda,
+        payments: paymentLambda,
+      },
+      restate: props.restateInstance,
+    });
+    handlers.register({
+      metaEndpoint: props.restateInstance.metaEndpoint,
+      invokerRoleArn: props.restateInstance.invokerRole.roleArn,
+      authTokenSecretArn: props.restateInstance.authToken?.secretArn,
+    });
   }
 }
 

--- a/lib/managed-restate-stack.ts
+++ b/lib/managed-restate-stack.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023 - Restate Software, Inc., Restate GmbH
+ *
+ * This file is part of the Restate SDK for Node.js/TypeScript,
+ * which is released under the MIT license.
+ *
+ * You can find a copy of the license in file LICENSE in the root
+ * directory of this repository or package, or at
+ * https://github.com/restatedev/sdk-typescript/blob/main/LICENSE
+ */
+
+import * as cdk from "aws-cdk-lib";
+import { Construct } from "constructs";
+import * as restate from "@restatedev/restate-cdk";
+
+export class ManagedRestateStack extends cdk.Stack {
+  readonly restateInstance: restate.RestateInstance;
+  readonly registrationProviderToken: cdk.CfnOutput;
+
+  constructor(scope: Construct, id: string, props: cdk.StackProps & restate.ManagedRestateProps) {
+    super(scope, id, props);
+
+    const restateInstance = new restate.ManagedRestate(this, "Restate", {
+      ...props,
+    });
+    this.restateInstance = restateInstance;
+
+    new cdk.CfnOutput(this, "RestateIngressEndpoint", {
+      value: restateInstance.ingressEndpoint,
+    });
+
+    this.registrationProviderToken = restateInstance.registrationProviderToken;
+  }
+}

--- a/lib/restate-cloud-stack.ts
+++ b/lib/restate-cloud-stack.ts
@@ -10,10 +10,10 @@
  */
 
 import * as cdk from "aws-cdk-lib";
-import { Construct } from "constructs";
 import * as restate from "@restatedev/restate-cdk";
+import { Construct } from "constructs";
 
-export class ManagedRestateStack extends cdk.Stack {
+export class RestateCloudStack extends cdk.Stack {
   readonly restateInstance: restate.RestateInstance;
   readonly registrationProviderToken: cdk.CfnOutput;
 

--- a/lib/self-hosted-restate-stack.ts
+++ b/lib/self-hosted-restate-stack.ts
@@ -11,16 +11,12 @@
 
 import * as cdk from "aws-cdk-lib";
 import * as logs from "aws-cdk-lib/aws-logs";
-import * as acm from "aws-cdk-lib/aws-certificatemanager";
-import { Construct } from "constructs";
 import * as restate from "@restatedev/restate-cdk";
+import { Construct } from "constructs";
 
 export interface SelfHostedRestateProps extends cdk.StackProps {
   /** Prefix for resources created by this construct that require unique names. */
   prefix?: string;
-
-  /** Optional certificate to use on ingress listener. If not set, a plain HTTP listener will be created! */
-  ingressCertificateArn?: string;
 }
 
 export class SelfHostedRestateStack extends cdk.Stack {
@@ -39,14 +35,14 @@ export class SelfHostedRestateStack extends cdk.Stack {
         removalPolicy: cdk.RemovalPolicy.DESTROY, // Set to RETAIN if you'd prefer to keep the logs after stack deletion
         retention: logs.RetentionDays.ONE_MONTH,
       }),
-      certificate: props.ingressCertificateArn
-        ? acm.Certificate.fromCertificateArn(this, "Certificate", props.ingressCertificateArn)
-        : undefined,
     });
     this.restateInstance = restateInstance;
 
     new cdk.CfnOutput(this, "RestateIngressEndpoint", {
-      value: restateInstance.publicIngressEndpoint,
+      value: restateInstance.ingressEndpoint,
+    });
+    new cdk.CfnOutput(this, "RestateMetaEndpoint", {
+      value: restateInstance.metaEndpoint,
     });
     new cdk.CfnOutput(this, "RestateHostInstanceId", {
       value: restateInstance.instance.instanceId,


### PR DESCRIPTION
Original revision:

- automate managed service handler registration
- update instructions for managed deployment
- remove unnecessary stack outputs from Holiday service stack

Added:

- keep up with changes to CDK constructs from https://github.com/restatedev/cdk/pull/17